### PR TITLE
KSR-456: Changed layer search to using all layer columns

### DIFF
--- a/src/main/client/src/components/app/side-bar/search/search-layer/SearchLayer.js
+++ b/src/main/client/src/components/app/side-bar/search/search-layer/SearchLayer.js
@@ -223,12 +223,33 @@ class SearchLayer extends Component<Props, State> {
             optionsField,
         } = searchState;
 
-        const buildQueryString = layer => parseQueryString(
-            searchFieldValues,
-            textSearch,
-            optionsField,
-            layer.queryColumnsList,
-        );
+        const buildQueryString = (layer: Object) => {
+            let queryFields = layer.queryColumnsList;
+
+            // if layer has fields defined then use them to build query
+            // if not then use query column list
+            if (layer.fields) {
+                const notAllowedFieldsToQuery = ['objectid', 'object', 'id', 'fid', 'symbolidentifier',
+                    'objectid_1', 'contract_uuid', 'shape'];
+                const fieldsToQuery = [];
+                layer.fields.forEach((field) => {
+                    if (typeof field.name === 'string'
+                        && notAllowedFieldsToQuery.indexOf(field.name.toLowerCase()) === -1) {
+                        fieldsToQuery.push(field.name);
+                    }
+                });
+                if (fieldsToQuery.length > 0) {
+                    queryFields = fieldsToQuery;
+                }
+            }
+
+            return parseQueryString(
+                searchFieldValues,
+                textSearch,
+                optionsField,
+                queryFields,
+            );
+        };
 
         const queryMap = new Map();
         if (selectedLayer === 'queryAll') {

--- a/src/main/client/src/translations/fi.js
+++ b/src/main/client/src/translations/fi.js
@@ -18,7 +18,7 @@ const fi = {
         buttonClear: 'Tyhjennä',
         chooseLayer: 'Valitse taso',
         searchAllFields: 'Hae kaikista kentistä',
-        searchAllFieldsInfo: 'Haku kohdistuu vain yleisimpiin kenttiin. Mikäli tarvetta tarkemmalle haulle, on mahdollista hakea yksittäiseltä aktiiviselta tasolta kerrallaan haluamillaan kentillä.',
+        searchAllFieldsInfo: 'Haku kohdistuu kaikkiin kenttiin. Mikäli tarvetta tarkemmalle haulle, on mahdollista hakea yksittäiseltä aktiiviselta tasolta kerrallaan haluamillaan kentillä.',
         addField: 'Lisää hakukenttä',
         searchLayerGroupName: 'Hakutulokset',
         allQueryableLayers: 'Kaikki tasot',


### PR DESCRIPTION
Search now uses layer fields when building search query.

Search query not use these field (filtered out):
- objectid
- object
- id
- fid
- symbolidenfier
- objectid_1
- contract_uuid
- shape

